### PR TITLE
加载压缩模型会导致报错

### DIFF
--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -146,7 +146,7 @@ class Dictionary(
 
 
     private fun addWordNgrams(line: IntArrayList,
-                              hashes: LongArrayList,
+                              hashes: IntArrayList,
                               n: Int) {
 
         val hashSize = hashes.size()

--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -96,7 +96,7 @@ class Dictionary(
      * words里面存放了
      */
     fun getLine(tokens: Iterable<String>, words: IntArrayList, labels: IntArrayList): Int {
-        val word_hashes = LongArrayList()
+        val word_hashes = IntArrayList()
         var ntokens = 0
 
         words.clear()
@@ -111,7 +111,7 @@ class Dictionary(
 
             if (type == EntryType.word) {
                 addSubwords(words, token, wid)
-                word_hashes.add(h.toLong())
+                word_hashes.add(h.toInt())
             } else if (type == EntryType.label && wid >= 0) {
                 labels.add(wid - nwords)
             }

--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -402,11 +402,12 @@ class Dictionary(
                     nlabels
             )
 
+            dict.pruneidxSize = pruneidxSize
+            dict.pruneidx = pruneidx
+
             dict.initTableDiscard()
             dict.initNgrams()
 
-            dict.pruneidxSize = pruneidxSize
-            dict.pruneidx = pruneidx
 
             dict.onehotMap.initWordHash2WordId()
 


### PR DESCRIPTION
当用此库加载压缩后的fasttext模型后，进行预测会导致数据越界错误。原因是加载词典一处代码的顺序问题，导致加载的词的hashId被错误记录。修复已经提交，简单修改代码顺序即可。