### PR TITLE
修复返回top k结果排序bug

### DIFF
--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -146,7 +146,7 @@ class Dictionary(
 
 
     private fun addWordNgrams(line: IntArrayList,
-                              hashes: LongArrayList,
+                              hashes: IntArrayList,
                               n: Int) {
 
         val hashSize = hashes.size()

--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -96,7 +96,7 @@ class Dictionary(
      * words里面存放了
      */
     fun getLine(tokens: Iterable<String>, words: IntArrayList, labels: IntArrayList): Int {
-        val word_hashes = LongArrayList()
+        val word_hashes = IntArrayList()
         var ntokens = 0
 
         words.clear()
@@ -111,7 +111,7 @@ class Dictionary(
 
             if (type == EntryType.word) {
                 addSubwords(words, token, wid)
-                word_hashes.add(h.toLong())
+                word_hashes.add(h.toInt())
             } else if (type == EntryType.label && wid >= 0) {
                 labels.add(wid - nwords)
             }

--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/dictionary/Dictionary.kt
@@ -402,11 +402,12 @@ class Dictionary(
                     nlabels
             )
 
+            dict.pruneidxSize = pruneidxSize
+            dict.pruneidx = pruneidx
+
             dict.initTableDiscard()
             dict.initNgrams()
 
-            dict.pruneidxSize = pruneidxSize
-            dict.pruneidx = pruneidx
 
             dict.onehotMap.initWordHash2WordId()
 

--- a/mynlp/src/main/java/com/mayabot/nlp/fasttext/loss/Loss.kt
+++ b/mynlp/src/main/java/com/mayabot/nlp/fasttext/loss/Loss.kt
@@ -55,14 +55,13 @@ abstract class Loss(val wo: Matrix) {
                 continue
             }
 
-            if (heap.size == k && stdLog(output[i]) < heap.first().score) {
+            if (heap.size == k && stdLog(output[i]) < heap.last().score) {
                 continue
             }
 
             heap += ScoreIdPair(stdLog(output[i]).toFloat(), i)
             heap.sortByDescending { it.score } // 从高到低排序
             if (heap.size > k) {
-                heap.sortByDescending { it.score }
                 heap.removeAt(heap.size - 1)
             }
         }


### PR DESCRIPTION
当获取top k的预测结果时，由于findBest方法的排序过滤bug，会导致正确的结果被排除在外。